### PR TITLE
Fix imports of profiling module

### DIFF
--- a/part2_advanced_config.ipynb
+++ b/part2_advanced_config.ipynb
@@ -118,12 +118,14 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "from hls4ml.model.profiling import numerical, get_ymodel_keras\n",
+    "\n",
     "for layer in config['LayerName'].keys():\n",
     "    config['LayerName'][layer]['Trace'] = True\n",
     "hls_model = hls4ml.converters.convert_from_keras_model(\n",
     "    model, hls_config=config, output_dir='model_1/hls4ml_prj_2', part='xcu250-figd2104-2L-e'\n",
     ")\n",
-    "hls4ml.model.profiling.numerical(model=model, hls_model=hls_model, X=X_test[:1000])"
+    "numerical(model=model, hls_model=hls_model, X=X_test[:1000])"
    ]
   },
   {
@@ -146,7 +148,7 @@
     "hls_model = hls4ml.converters.convert_from_keras_model(\n",
     "    model, hls_config=config, output_dir='model_1/hls4ml_prj_2', part='xcu250-figd2104-2L-e'\n",
     ")\n",
-    "hls4ml.model.profiling.numerical(model=model, hls_model=hls_model)\n",
+    "numerical(model=model, hls_model=hls_model)\n",
     "hls4ml.utils.plot_model(hls_model, show_shapes=True, show_precision=True, to_file=None)"
    ]
   },
@@ -190,7 +192,7 @@
    "source": [
     "hls_model.compile()\n",
     "hls4ml_pred, hls4ml_trace = hls_model.trace(X_test[:1000])\n",
-    "keras_trace = hls4ml.model.profiling.get_ymodel_keras(model, X_test[:1000])\n",
+    "keras_trace = get_ymodel_keras(model, X_test[:1000])\n",
     "y_hls = hls_model.predict(X_test)"
    ]
   },

--- a/part6_cnns.ipynb
+++ b/part6_cnns.ipynb
@@ -715,6 +715,7 @@
    "outputs": [],
    "source": [
     "from hls4ml.model.profiling import numerical\n",
+    "\n",
     "numerical(model=model, hls_model=hls_model)"
    ]
   },

--- a/part6_cnns.ipynb
+++ b/part6_cnns.ipynb
@@ -714,7 +714,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hls4ml.model.profiling.numerical(model=model, hls_model=hls_model)"
+    "from hls4ml.model.profiling import numerical\n",
+    "numerical(model=model, hls_model=hls_model)"
    ]
   },
   {
@@ -767,7 +768,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hls4ml.model.profiling.numerical(model=qmodel, hls_model=hls_model_q)\n",
+    "numerical(model=qmodel, hls_model=hls_model_q)\n",
     "hls4ml.utils.plot_model(hls_model_q, show_shapes=True, show_precision=True, to_file=None)"
    ]
   },


### PR DESCRIPTION
With upcoming changes in fastmachinelearning/hls4ml#1094 the `profiling` module is not imported automatically when importing `hls4ml`, instead `from hls4ml.model.profiling import ...` should be used. This is compatible with released 1.0.0 version.